### PR TITLE
Lint test and url in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,17 @@
 from setuptools import setup
 
+_dependencies = ['requests', 'gitpython', 'pyserial', 'python-dateutil']
+
 setup(
     name='friskby',
-    version='0.61.0',
+    version='0.61.1',
     description='The friskby module',
-    url='http://github.com/FriskbyBergen/friskby',
+    url='http://github.com/FriskbyBergen/python-friskby',
     author='Friskby Bergen',
     author_email='pgdr@statoil.com',
-    license='GPL v3',
+    license='GNU General Public License, Version 3',
     packages=['friskby'],
-    zip_safe=False
+    zip_safe=False,
+    setup_requires=_dependencies,
+    install_requires=_dependencies
 )

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -5,32 +5,27 @@ import os.path
 from unittest import TestLoader, TextTestRunner
 from friskby import SDS011
 
-TEST_PYTHONPATH = "%s:%s" % (os.path.abspath(os.path.join(os.path.dirname(__file__), "../lib")),
-                             os.path.abspath(os.path.dirname(__file__)))
-
-os.environ["PYTHONPATH"] = TEST_PYTHONPATH + os.pathsep + os.getenv("PYTHONPATH", "")
-for path_element in reversed(TEST_PYTHONPATH.split(os.pathsep)):
-    sys.path.insert(0, path_element)
-
-
 if SDS011.is_mock():
     os.environ["FRISKBY_TEST"] = "True"
 
-
-def findTestsInDirectory(path, recursive=True, pattern="test*.py"):
+def find_tests(path, recursive=True, pattern="test*.py"):
     loader = TestLoader()
     test_suite = loader.discover(path, pattern=pattern)
 
     for (root, dirnames, _) in os.walk(path):
         for directory in dirnames:
-            test_suite.addTests(findTestsInDirectory(os.path.join(root, directory),
-                                                     recursive, pattern))
+            test_suite.addTests(find_tests(os.path.join(root, directory),
+                                           recursive, pattern))
 
     return test_suite
 
+def run_tests():
+    test_suite = find_tests(os.path.dirname(__file__))
+    test_runner = TextTestRunner(verbosity=1)
+    test_run = test_runner.run(test_suite)
+    return test_run.wasSuccessful()
 
-TEST_SUITE = findTestsInDirectory(os.path.dirname(__file__))
-TEST_RUNNER = TextTestRunner(verbosity=1)
-TEST_RUNNER.run(TEST_SUITE)
-if not TEST_RUNNER.run(TEST_SUITE).wasSuccessful():
-    sys.exit('RPiParticle test failed!')
+if __name__ == '__main__':
+    SUCCESS = run_tests()
+    if not SUCCESS:
+        sys.exit('RPiParticle test failed!')


### PR DESCRIPTION
This is a minor change.
1. Fix url in `setup.py` and expand `license`
2. lint testing now uses `which pylint` instead of OSError-ing.