### PR TITLE
Make directory structure for new FriskbyDao

### DIFF
--- a/friskby/__init__.py
+++ b/friskby/__init__.py
@@ -35,4 +35,4 @@ __all__ = ['FriskbyDao', 'FriskbySampler', 'FriskbySubmitter', 'FriskbyRunner',
            'SDS011', 'ServiceConfig', 'TS', 'GitModule', 'DeviceConfig',
            'sys_info']
 
-__version__ = '0.61.2'
+__version__ = '0.62.0'

--- a/friskby/friskby_dao.py
+++ b/friskby/friskby_dao.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 
 import sys
 from sys import stderr, argv
-from os.path import abspath, isfile
+from os import makedirs
+from os.path import abspath, isfile, isdir, split
 import sqlite3
 from datetime import datetime as dt
 from dateutil import parser as dt_parser
@@ -25,7 +26,12 @@ class FriskbyDao(object):
         return self._sql_path
 
     def __init_sql(self):
-        # TODO make directory if not exists
+        if isfile(self._sql_path):
+            return # nothing to do
+
+        _path, _ = split(self._sql_path)
+        if not isdir(_path):
+            makedirs(_path) # equivalent to `mkdir -p _path`
         if not isfile(self._sql_path):
             print('No database, constructing new: %s.' % self._sql_path)
             _id = '`id` INTEGER PRIMARY KEY'

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,18 @@
 from setuptools import setup
 
-_dependencies = ['requests', 'gitpython', 'pyserial', 'python-dateutil']
+DEPENDENCIES = ['requests', 'gitpython', 'pyserial', 'python-dateutil']
 
 setup(
     name='friskby',
-    version='0.61.2',
+    version='0.62.0',
     description='The friskby module',
     url='http://github.com/FriskbyBergen/python-friskby',
     author='Friskby Bergen',
+    keywords='friskby bergen frisk by python-friskby a-small-code air',
     author_email='pgdr@statoil.com',
     license='GNU General Public License, Version 3',
     packages=['friskby'],
     zip_safe=False,
-    setup_requires=_dependencies,
-    install_requires=_dependencies
+    setup_requires=DEPENDENCIES,
+    install_requires=DEPENDENCIES
 )


### PR DESCRIPTION
there was an issue where the FriskbyDao would crash if you gave it a non-existing directory structure, e.g. `/tmp/a/b/c/d/e/friskby.sql`.  Now we construct the directory structure.

1. construct directory structure for database file
2. bump version number