### PR TITLE
sds011 takes path to device, rewrote mocking

### DIFF
--- a/friskby/__init__.py
+++ b/friskby/__init__.py
@@ -11,24 +11,12 @@ from .friskby_runner import FriskbyRunner
 from .friskby_submitter import FriskbySubmitter
 from .os_release import sys_info
 
-try:
-    from sds011 import SDS011
-except ImportError as err:
-    import sys
-    sys.stderr.write('Missing SDS011 library: %s\n' % str(err))
-    sys.stderr.write('Using mock library.\n')
-    sys.stderr.flush()
-    from .mock_sds011 import SDS011
-except SerialException as err:
-    import sys
-    sys.stderr.write('Using mock SDS011 serial device: %s\n' % str(err))
-    sys.stderr.write('Using mock library.\n')
-    sys.stderr.flush()
-    from .mock_sds011 import SDS011
+from .sds011 import SDS011
+from .mock_sds011 import MockSDS011
 
 from .ts import TS
 
 __all__ = ['FriskbyDao', 'FriskbySampler', 'FriskbySubmitter', 'FriskbyRunner',
            'SDS011', 'TS', 'DeviceConfig', 'sys_info']
 
-__version__ = '0.63.0'
+__version__ = '0.64.0'

--- a/friskby/mock_sds011.py
+++ b/friskby/mock_sds011.py
@@ -1,11 +1,7 @@
-class SDS011(object):
+class MockSDS011(object):
 
-    def __init__(self, usb):
-        self.usb = usb
+    def __init__(self, device_url):
+        self.device_url = device_url
 
     def read(self):
-        return (10, 25)
-
-    @classmethod
-    def is_mock(cls):
-        return True
+        return (10.0, 2.5)

--- a/friskby/sds011.py
+++ b/friskby/sds011.py
@@ -1,61 +1,58 @@
 from __future__ import division
 
-import serial
 import time
+import serial
+
 
 class SDS011(object):
-    msg_start  = 170
-    msg_cmd    = 192
-    msg_end    = 171
+    """A class for reading PM10 and PM25 from the SDS011 sensor.'
 
-    sleep_time = 0.01
+    Takes as input the path to the device, e.g. 'dev/ttyUSB0' or
+    '/dev/tty/AMA0'.  Has one method, read, which reads for
 
-    device_usb = serial.Serial('/dev/ttyUSB0', baudrate=9600, stopbits=1, parity="N", timeout=2)
-    device_ama = serial.Serial('/dev/ttyAMA0', baudrate=9600, stopbits=1, parity="N", timeout=2)
+    """
+    MSG_START = 170  # AAC0
+    MSG_CMD = 192
+    MSG_END = 171
 
-    def __init__(self, usb):
-        if usb:
-            self.device = SDS011.device_usb
-        else:
-            self.device = SDS011.device_ama
+    def __init__(self, device_path, sleep_time=0.01):
+        self.sleep_time = sleep_time
+        self.device = serial.Serial(device_path, baudrate=9600,
+                                    stopbits=1, parity="N", timeout=2)
+
+    def _fastforward(self):
+        """Reads from device until [MSG_START=AAC0, MSG_CMD] encountered"""
+        while True:
+            byte_read = self.device.read(1)
+            if len(byte_read) < 1:
+                raise IOError('Device timed out in attempt to read a byte.')
+            if ord(byte_read) == SDS011.MSG_START:
+                byte_read = self.device.read(1)
+                if ord(byte_read) == SDS011.MSG_CMD:
+                    return
+            time.sleep(self.sleep_time)
+
+    def _read_values(self):
+        """Reads 8 values as bytes and their int values"""
+        bytes_read = self.device.read(8)
+        if len(bytes_read) != 8:
+            raise IOError('Device timed out in attempt to read values.')
+        return map(ord, bytes_read)
 
     def read(self):
-
-        # Read in loop until message start: AAC0
-        while True:
-            s = self.device.read(1)
-            if len(s) < 1:
-                raise IOError('Device timed out in attempt to read a byte')
-            if ord(s) == SDS011.msg_start:
-                s = self.device.read(1)
-                if ord(s) == SDS011.msg_cmd:
-                    break
-            time.sleep(SDS011.sleep_time)
-
-        s = self.device.read(8)
-
-        pm25hb = ord(s[0])
-        pm25lb = ord(s[1])
-        pm10hb = ord(s[2])
-        pm10lb = ord(s[3])
-        d5     = ord(s[4])
-        d6     = ord(s[5])
-
-        cs     = ord(s[6])
-        tail   = ord(s[7])
+        """Samples from sensor, verifies correctness and returns a pair
+        of float values (pm10, pm25)."""
+        self._fastforward()
+        pm25hb, pm25lb, pm10hb, pm10lb, d5, d6, cs, tail = self._read_values()
 
         cs_expected = (pm25hb + pm25lb + pm10hb + pm10lb + d5 + d6) % 256
         if cs != cs_expected:
             raise Exception("Checksum test failed")
 
-        if tail != SDS011.msg_end:
+        if tail != SDS011.MSG_END:
             raise Exception("Message was not correctly terminated?")
 
         pm25 = float(pm25hb + pm25lb*256)/10.0
         pm10 = float(pm10hb + pm10lb*256)/10.0
 
         return (pm10, pm25)
-
-    @classmethod
-    def is_mock(cls):
-        return False

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ DEPENDENCIES = ['requests', 'pyserial', 'python-dateutil']
 
 setup(
     name='friskby',
-    version='0.63.0',
+    version='0.64.0',
     description='The friskby module',
     url='http://github.com/FriskbyBergen/python-friskby',
     author='Friskby Bergen',

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -5,8 +5,7 @@ import os.path
 from unittest import TestLoader, TextTestRunner
 from friskby import SDS011
 
-if SDS011.is_mock():
-    os.environ["FRISKBY_TEST"] = "True"
+os.environ["FRISKBY_TEST"] = "True"
 
 def find_tests(path, recursive=True, pattern="test*.py"):
     loader = TestLoader()

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -2,7 +2,7 @@ from tempfile import NamedTemporaryFile as temp
 from datetime import datetime as dt
 from unittest import TestCase
 
-from friskby import FriskbyDao, FriskbySampler, SDS011
+from friskby import FriskbyDao, FriskbySampler, MockSDS011
 
 class SamplerTest(TestCase):
 
@@ -17,8 +17,8 @@ class SamplerTest(TestCase):
         sleep_time = 0.10
 
         start = dt.now()
-        sampler = FriskbySampler(SDS011(True), self.dao, sample_time=sample_time,
-                                 sleep_time=sleep_time)
+        sampler = FriskbySampler(MockSDS011('/path/to/dev'), self.dao,
+                                 sample_time=sample_time, sleep_time=sleep_time)
         sampler.collect()
         stop = dt.now()
 

--- a/tests/test_sds011.py
+++ b/tests/test_sds011.py
@@ -1,17 +1,9 @@
 from unittest import TestCase, skipUnless, skipIf
-from friskby import SDS011
-
-have_SDS011 = not SDS011.is_mock()
+from friskby import MockSDS011
 
 class SDS011Test(TestCase):
 
-    @skipUnless(have_SDS011, "Must be on RPi with /dev/ttyUSB0 to run test")
-    def test_read(self):
-        _ = SDS011(True).read()
-
-
-    @skipIf(have_SDS011, "Test based on Mock SDS011")
     def test_read_mock(self):
-        pm10, pm25 = SDS011(True).read()
-        self.assertEqual(pm10, 10)
-        self.assertEqual(pm25, 25)
+        pm10, pm25 = MockSDS011('/device/sds011').read()
+        self.assertEqual(10.0, pm10)
+        self.assertEqual(2.5, pm25)


### PR DESCRIPTION
`FriskbySettings` will determine the path to the `SDS011` device, no more hardcoded `ttyUSB0`.

The downstream is in FriskByBergen/RpiParticle#123

One small step towards FriskByBergen/RpiParticle#118