### PR TITLE
persist_ts takes a dict sensor,ts

### DIFF
--- a/friskby/friskby_sampler.py
+++ b/friskby/friskby_sampler.py
@@ -42,4 +42,5 @@ class FriskbySampler(object):
             time.sleep(self.sleep_time)
         print('\tDone collecting, storing and returning.')
         sys.stdout.flush()
-        self.dao.persist_ts(data)
+        samples = {'PM10': data[0], 'PM25': data[1]}
+        self.dao.persist_ts(samples)

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -47,7 +47,8 @@ class DaoTest(TestCase):
         for _ in range(num_data):
             t10 = gen_rand_ts()
             t25 = gen_rand_ts()
-            self.dao.persist_ts((t10, t25))
+            data = {'PM10': t10, 'PM25': t25}
+            self.dao.persist_ts(data)
 
         self._do_test_num_upl(self.dao, 2*num_data, 0, 2*num_data)
 
@@ -59,7 +60,8 @@ class DaoTest(TestCase):
         for _ in range(num_data):
             t10 = gen_rand_ts()
             t25 = gen_rand_ts()
-            self.dao.persist_ts((t10, t25))
+            data = {'PM10': t10, 'PM25': t25}
+            self.dao.persist_ts(data)
         print(repr(self.dao))
 
         self._do_test_num_upl(self.dao, 2*num_data, 0, 2*num_data)
@@ -78,7 +80,8 @@ class DaoTest(TestCase):
         t10 = gen_rand_ts()
         t25 = gen_rand_ts()
         now = dt.now()
-        self.dao.persist_ts((t10, t25))
+        data = {'PM10': t10, 'PM25': t25}
+        self.dao.persist_ts(data)
         out = self.dao.get_non_uploaded(limit=1)[0]
         delta = now - out[3]
         # checking that we're in the same timezone
@@ -92,7 +95,8 @@ class DaoTest(TestCase):
         self.assertEqual(_fpath, sqlpath)
         t10 = gen_rand_ts(value=26.8)
         t25 = gen_rand_ts(value=19.90)
-        dao.persist_ts((t10, t25))
+        data = {'PM10': t10, 'PM25': t25}
+        dao.persist_ts(data)
         # data: 2 elts of (id, value, sensor, timestamp, upl)
         data = dao.get_non_uploaded()
         self.assertEqual(2, len(data))
@@ -110,7 +114,8 @@ class DaoTest(TestCase):
 
         t10 = gen_rand_ts()
         t25 = gen_rand_ts()
-        self.dao.persist_ts((t10, t25))
+        data = {'PM10': t10, 'PM25': t25}
+        self.dao.persist_ts(data)
         self.assertIsNone(self.dao.last_entry(uploaded=True))
         self.assertIsNotNone(self.dao.last_entry(uploaded=False))
         self.assertIsNotNone(self.dao.last_entry())
@@ -121,7 +126,8 @@ class DaoTest(TestCase):
         self.assertIsNotNone(self.dao.last_entry())
         t10 = gen_rand_ts()
         t25 = gen_rand_ts()
-        self.dao.persist_ts((t10, t25))
+        data = {'PM10': t10, 'PM25': t25}
+        self.dao.persist_ts(data)
         self.assertIsNotNone(self.dao.last_entry(uploaded=True))
         self.assertIsNotNone(self.dao.last_entry(uploaded=False))
         self.assertIsNotNone(self.dao.last_entry())

--- a/tests/test_submitter.py
+++ b/tests/test_submitter.py
@@ -1,12 +1,18 @@
-import tempfile
+from tempfile import NamedTemporaryFile as temp
 from unittest import TestCase
 from friskby import FriskbySubmitter, DeviceConfig
 
 class FriskbySubmitterTest(TestCase):
 
+    def _temp_fname(self, postfix=''):
+        tmpf = temp(delete=False)
+        fname = tmpf.name + postfix
+        tmpf.close()
+        return fname
+
     def setUp(self):
-        _, self.cfg_fname = tempfile.mkstemp()
-        _, self.sql_fname = tempfile.mkstemp()
+        self.sql_fname = self._temp_fname('_db.sql')
+        self.cfg_fname = self._temp_fname('_.cfg')
         url_ = "https://friskby.herokuapp.com/sensor/api/device/FriskPITest/"
         deviceconfig = DeviceConfig.download(url_, post_key="xxx")
         deviceconfig.save(filename=self.cfg_fname)


### PR DESCRIPTION
To prepare for new more sensors, the DAO can now take an arbitrary sensor type and persist.

The API for the dao is now that the function `persist_ts` takes a dict of `sensor, timeseries` pairs:
```python
data = {'PM10' : ts_pm10, 'PM25': ts_pm25}
dao.persist_ts(data)
```

When we add more sensors, e.g. `RH`, we may thus use the dao in the exact same way:
```python
data = {'PM10' : ts_pm10, 'PM25': ts_pm25, 'RH': ts_rh}
dao.persist_ts(data)
```
